### PR TITLE
Correcao na rotina que excluir propriedades no Map

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,1 +1,2 @@
 .vscode
+.DS_Store

--- a/app/json_map/json_map.go
+++ b/app/json_map/json_map.go
@@ -116,7 +116,7 @@ func RemoveProperties(jsonValue []byte, propertiesName []string) []byte {
 
 	currentJsonValue := jsonValue
 	for _, property := range propertiesName {
-		currentJsonValue = RemoveProperty(jsonValue, property)
+		currentJsonValue = RemoveProperty(currentJsonValue, property)
 	}
 
 	return currentJsonValue


### PR DESCRIPTION
A rotina nao estava aplicando a recursividade corretamente, o parametro era sempre o base ao inves do ja manipulado pela recursividade