### PR TITLE
Fix: Make RemoveProperty delete keys regardless of value type

### DIFF
--- a/app/json_map/json_map.go
+++ b/app/json_map/json_map.go
@@ -164,18 +164,18 @@ func RemoveProperty(jsonMap map[string]interface{}, propertyName string) map[str
 	total := len(propertyNameSplitted)
 
 	for i, property := range propertyNameSplitted {
-		valueTemp, ok := jsonMapCurrent[property].(map[string]interface{})
-
-		if ok && i+1 == total {
+		if i == total-1 {
 			delete(jsonMapCurrent, property)
 			break
-		} else {
-			jsonMapCurrent = valueTemp
 		}
 
-		if i+1 == total {
-			delete(jsonMapCurrent, property)
+		valueTemp, ok := jsonMapCurrent[property].(map[string]interface{})
+
+		if !ok {
+			break
 		}
+
+		jsonMapCurrent = valueTemp
 	}
 
 	return jsonMap


### PR DESCRIPTION
RemoveProperty was requiring values to be map[string]interface{} before deletion. Now it deletes properties regardless of value type.