### PR TITLE
Fix: Handle nil value in GetValueBodyContext

### DIFF
--- a/app/contexts/command_context.go
+++ b/app/contexts/command_context.go
@@ -103,7 +103,7 @@ func GetValueBodyContext(command string, bodyContext *BodyContext) interface{} {
 		propertyName := strings.ReplaceAll(command, prefixBodyContext, "")
 		jsonMap := bodyContext.ParseBodyToMapObject()
 		value, _ := json_map.GetValue(jsonMap, propertyName, false)
-		if len(fmt.Sprint(value)) == 0 && propertyName == "currentBody" {
+		if (value == nil || len(fmt.Sprint(value)) == 0) && propertyName == "currentBody" {
 			value = bodyContext.GetBodyString()
 		}
 		return value


### PR DESCRIPTION
As of now, this logic is failing to handle nil values. Currently, if value is nil `fmt.Sprint(value)` will return `<nil>` and when using the `len`  function it will return 5, which can be missleading, since we generally expect for the length of nil values to equal zero.
