### PR TITLE
Create formatDate logic for parsing date string inputs

### DIFF
--- a/app/contexts/command_context.go
+++ b/app/contexts/command_context.go
@@ -221,7 +221,7 @@ func ParseValues(jsonMap map[string]interface{}, parse *maps.ParseSettings) map[
 func formatDate(dateValue string, targetFormat string) (string, error) {
 	t, err := time.Parse(time.RFC3339Nano, dateValue)
 	if err != nil {
-		return dateValue, err
+		return "", err
 	}
 
 	replacer := strings.NewReplacer(

--- a/app/contexts/command_context.go
+++ b/app/contexts/command_context.go
@@ -166,29 +166,6 @@ func CreatePropertyInterpolationValue(jsonMap map[string]interface{}, propertyNa
 	return json_map.CreateProperty(jsonMap, propertyName, valueResult)
 }
 
-func FormatDate(dateValue string, targetFormat string) string {
-	t, err := time.Parse(time.RFC3339Nano, dateValue)
-	if err != nil {
-		panic(err)
-	}
-
-	replacer := strings.NewReplacer(
-		"yyyy", "2006",
-		"yy", "06",
-		"MM", "01",
-		"dd", "02",
-		"HH", "15",
-		"hh", "03",
-		"mm", "04",
-		"ss", "05",
-		"tt", "PM",
-	)
-
-	layout := replacer.Replace(targetFormat)
-
-	return t.Format(layout)
-}
-
 func ParseValues(jsonMap map[string]interface{}, parse *maps.ParseSettings) map[string]interface{} {
 	jsonValueCurrent := jsonMap
 	if parse.WhenEquals != nil {
@@ -238,12 +215,40 @@ func ParseValues(jsonMap map[string]interface{}, parse *maps.ParseSettings) map[
 		}
 	}
 
-	if len(parse.FormatDate) > 0 {
-		for _, formatDate := range parse.FormatDate {
-				formatDateSplitted := strings.Split(formatDate, ":")
+	return jsonValueCurrent
+}
 
-				propertyName := formatDateSplitted[0]
-				targetFormat := formatDateSplitted[1]
+func formatDate(dateValue string, targetFormat string) string {
+	t, err := time.Parse(time.RFC3339Nano, dateValue)
+	if err != nil {
+		panic(err)
+	}
+
+	replacer := strings.NewReplacer(
+		"yyyy", "2006",
+		"yy", "06",
+		"MM", "01",
+		"dd", "02",
+		"HH", "15",
+		"hh", "03",
+		"mm", "04",
+		"ss", "05",
+		"tt", "PM",
+	)
+
+	layout := replacer.Replace(targetFormat)
+
+	return t.Format(layout)
+}
+
+func FormatValues(jsonMap map[string]interface{}, format *maps.FormatSettings) map[string]interface{} {
+	jsonValueCurrent := jsonMap
+	if len(format.Date) > 0 {
+		for _, Date := range format.Date {
+				DateSplitted := strings.Split(Date, ":")
+
+				propertyName := DateSplitted[0]
+				targetFormat := DateSplitted[1]
 
 				dateValue, jsonMapResult := json_map.GetValue(jsonValueCurrent, propertyName, true)
 
@@ -252,7 +257,7 @@ func ParseValues(jsonMap map[string]interface{}, parse *maps.ParseSettings) map[
 					continue
 				}
 
-				var formatedDate = FormatDate(strDate, targetFormat)
+				var formatedDate = formatDate(strDate, targetFormat)
 				jsonValueCurrent = json_map.CreateProperty(jsonMapResult, propertyName, formatedDate)
 		}
 	}

--- a/app/handlers/http_contract_map_handler.go
+++ b/app/handlers/http_contract_map_handler.go
@@ -82,6 +82,10 @@ func (handler *HttpContractMapHandler) doDefault(wrenchContext *contexts.WrenchC
 		currentBodyContext = contexts.ParseValues(currentBodyContext, handler.ContractMap.Parse)
 	}
 
+	if handler.ContractMap.Format != nil {
+		currentBodyContext = contexts.FormatValues(currentBodyContext, handler.ContractMap.Format)
+	}
+
 	return currentBodyContext
 }
 
@@ -101,6 +105,8 @@ func (handler *HttpContractMapHandler) doSequency(wrenchContext *contexts.Wrench
 			currentBodyContext = json_map.DuplicatePropertiesValue(currentBodyContext, handler.ContractMap.Duplicate)
 		} else if action == "parse" {
 			currentBodyContext = contexts.ParseValues(currentBodyContext, handler.ContractMap.Parse)
+		} else if action == "format" {
+			currentBodyContext = contexts.FormatValues(currentBodyContext, handler.ContractMap.Format)
 		}
 	}
 

--- a/app/handlers/http_contract_map_handler.go
+++ b/app/handlers/http_contract_map_handler.go
@@ -144,6 +144,7 @@ func (handler *HttpContractMapHandler) SetNext(next Handler) {
 
 func (handler *HttpContractMapHandler) setHasError(span trace.Span, msg string, err error, httpStatusCode int, wrenchContext *contexts.WrenchContext, bodyContext *contexts.BodyContext) {
 	wrenchContext.SetHasError(span, msg, err)
+	bodyContext.ContentType = "text/plain"
 	bodyContext.HttpStatusCode = httpStatusCode
 	bodyContext.SetBody([]byte(msg))
 }

--- a/app/manifest/contract_settings/maps/contract_map_settings.go
+++ b/app/manifest/contract_settings/maps/contract_map_settings.go
@@ -7,16 +7,17 @@ import (
 	"wrench/app/manifest/validation"
 )
 
-var funcValids = []string{"rename", "new", "remove", "duplicate", "parse"}
+var funcValids = []string{"rename", "new", "remove", "duplicate", "parse", "format"}
 
 type ContractMapSetting struct {
-	Id        string         `yaml:"id"`
-	Rename    []string       `yaml:"rename"`
-	Remove    []string       `yaml:"remove"`
-	Sequence  []string       `yaml:"sequence"`
-	New       []string       `yaml:"new"`
-	Duplicate []string       `yaml:"duplicate"`
-	Parse     *ParseSettings `yaml:"parse"`
+	Id        string          `yaml:"id"`
+	Rename    []string        `yaml:"rename"`
+	Remove    []string        `yaml:"remove"`
+	Sequence  []string        `yaml:"sequence"`
+	New       []string        `yaml:"new"`
+	Duplicate []string        `yaml:"duplicate"`
+	Parse     *ParseSettings  `yaml:"parse"`
+	Format    *FormatSettings `yaml:"format"`
 }
 
 func (setting ContractMapSetting) Valid() validation.ValidateResult {
@@ -78,6 +79,11 @@ func (setting ContractMapSetting) Valid() validation.ValidateResult {
 		result.AppendValidable(setting.Parse)
 	}
 
+	if setting.Format != nil {
+		totalMapConfigured++
+		result.AppendValidable(setting.Format)
+	}
+
 	if len(setting.Sequence) > 0 {
 
 		if totalMapConfigured != len(setting.Sequence) {
@@ -97,6 +103,8 @@ func (setting ContractMapSetting) Valid() validation.ValidateResult {
 				result.AddError("contract.maps.sequence remove not configured")
 			} else if s == "parse" && setting.Parse == nil {
 				result.AddError("contract.maps.sequence parse not configured")
+			} else if s == "format" && setting.Format == nil {
+				result.AddError("contract.maps.sequence format not configured")
 			}
 		}
 	}

--- a/app/manifest/contract_settings/maps/format_settings.go
+++ b/app/manifest/contract_settings/maps/format_settings.go
@@ -1,0 +1,19 @@
+package maps
+
+import (
+	"wrench/app/manifest/validation"
+)
+
+type FormatSettings struct {
+	Date []string `yaml:"date"`
+}
+
+func (setting FormatSettings) Valid() validation.ValidateResult {
+	var result validation.ValidateResult
+
+	if len(setting.Date) == 0 {
+		result.AddError("contract.maps.format should configure Date")
+	}
+
+	return result
+}

--- a/app/manifest/contract_settings/maps/format_settings.go
+++ b/app/manifest/contract_settings/maps/format_settings.go
@@ -1,6 +1,7 @@
 package maps
 
 import (
+	"strings"
 	"wrench/app/manifest/validation"
 )
 
@@ -13,6 +14,18 @@ func (setting FormatSettings) Valid() validation.ValidateResult {
 
 	if len(setting.Date) == 0 {
 		result.AddError("contract.maps.format should configure Date")
+	} else {
+		for _, property := range setting.Date {
+			errorSplitted := "contract.maps.format should be configured as 'datePropertyName:dateFormat' without spaces"
+			if strings.Contains(property, " ") {
+				result.AddError(errorSplitted)
+			}
+
+			propertySplitted := strings.Split(property, ":")
+			if len(propertySplitted) != 2 {
+				result.AddError(errorSplitted)
+			}
+		}
 	}
 
 	return result

--- a/app/manifest/contract_settings/maps/parse_settings.go
+++ b/app/manifest/contract_settings/maps/parse_settings.go
@@ -7,16 +7,14 @@ import (
 type ParseSettings struct {
 	WhenEquals []string `yaml:"whenEquals"`
 	ToArray    []string `yaml:"toArray"`
-	FormatDate []string `yaml:"formatDate"`
 }
 
 func (setting ParseSettings) Valid() validation.ValidateResult {
 	var result validation.ValidateResult
 
 	if len(setting.WhenEquals) == 0 &&
-		len(setting.ToArray) == 0 &&
-		len(setting.FormatDate) == 0 {
-		result.AddError("contract.maps.parse should configure whenEquals, toArray or formatDate")
+		len(setting.ToArray) == 0 {
+		result.AddError("contract.maps.parse should configure whenEquals or toArray")
 	}
 
 	return result

--- a/app/manifest/contract_settings/maps/parse_settings.go
+++ b/app/manifest/contract_settings/maps/parse_settings.go
@@ -7,14 +7,16 @@ import (
 type ParseSettings struct {
 	WhenEquals []string `yaml:"whenEquals"`
 	ToArray    []string `yaml:"toArray"`
+	FormatDate []string `yaml:"formatDate"`
 }
 
 func (setting ParseSettings) Valid() validation.ValidateResult {
 	var result validation.ValidateResult
 
 	if len(setting.WhenEquals) == 0 &&
-		len(setting.ToArray) == 0 {
-		result.AddError("contract.maps.parse should configure whenEquals or toArray")
+		len(setting.ToArray) == 0 &&
+		len(setting.FormatDate) == 0 {
+		result.AddError("contract.maps.parse should configure whenEquals, toArray or formatDate")
 	}
 
 	return result

--- a/configAppContractMaps.yaml
+++ b/configAppContractMaps.yaml
@@ -67,13 +67,15 @@ contract:
   - id: map_before
     sequence:
     - parse
+    - format
     parse:
       toArray:
       - "phone:phones"
       - "address"
       - "customer.phone:customer.phones"
       - "customer:customers"
-      formatDate:
+    format:
+      date:
       - "createdAt:yyyyMMdd"
 
   - id: map_after

--- a/configAppContractMaps.yaml
+++ b/configAppContractMaps.yaml
@@ -73,6 +73,8 @@ contract:
       - "address"
       - "customer.phone:customer.phones"
       - "customer:customers"
+      formatDate:
+      - "createdAt:yyyyMMdd"
 
   - id: map_after
     sequence:


### PR DESCRIPTION
Add logic for converting dates to a specified format provided by the user.

For example, if a user has the following request body: 
`{"createdAt": "2025-07-03T10:42:38.569-03:00"}`

Using the formatDate with the value "createdAt:yyyyMMdd" should transform it to:
`{"createdAt": "20250703"}`