### PR TITLE
Add func.currentDate(utc) to return the current date in ISO 8601 format

### DIFF
--- a/app/contexts/func_general.go
+++ b/app/contexts/func_general.go
@@ -15,6 +15,8 @@ func GetFuncValue(funcType func_settings.FuncGeneralType, wrenchContext *WrenchC
 	case func_settings.FuncTypeBase64Encode:
 		bodyArray := bodyContext.GetBody(action)
 		return base64.StdEncoding.EncodeToString(bodyArray)
+	case func_settings.FuncTypeCurrentDate:
+		return getCurrentDateUtc()
 	default:
 		return ""
 	}
@@ -22,4 +24,8 @@ func GetFuncValue(funcType func_settings.FuncGeneralType, wrenchContext *WrenchC
 
 func getTimestamp() string {
 	return strconv.FormatInt(time.Now().UTC().UnixMilli(), 10)
+}
+
+func getCurrentDateUtc() string {
+	return time.Now().UTC().Format(time.RFC3339)
 }

--- a/app/manifest/action_settings/func_settings/func_settings.go
+++ b/app/manifest/action_settings/func_settings/func_settings.go
@@ -9,6 +9,7 @@ type FuncGeneralType string
 const (
 	FuncTypeTimestampMilli FuncGeneralType = "func.timestamp(milli)"
 	FuncTypeBase64Encode   FuncGeneralType = "func.base64(encode)"
+	FuncTypeCurrentDate    FuncGeneralType = "func.currentDate(utc)"
 )
 
 type FuncSettings struct {
@@ -27,6 +28,7 @@ func (setting FuncSettings) Valid() validation.ValidateResult {
 
 	if len(setting.Command) > 0 {
 		if string(setting.Command) == "{{"+string(FuncTypeTimestampMilli)+"}}" ||
+			string(setting.Command) == "{{"+string(FuncTypeCurrentDate)+"}}" ||
 			string(setting.Command) == "{{"+string(FuncTypeBase64Encode)+"}}" == false {
 			result.AddError("actions.func.command is invalid")
 		}


### PR DESCRIPTION
Add a new helper function `func.currentDate(utc)` that returns the current UTC date and time in ISO 8601 format (`"2025-07-23T19:08:41Z"`).

This allows users to dynamically inject the current timestamp into Kafka messages or other runtime contexts using `funcVarContext`.

Example use case:

```
- id: var_context
  type: funcVarContext
  body:
    preserveCurrentBody: true
  trigger:
    after:
      contractMapId: before_publish
  func:
    vars:
      "CurrentDate": "{{func.currentDate(utc)}}"
```

```
contract:
  maps:
  - id: before_publish
    new:
    - "UpdatedAt:{{bodyContext.actions.var_context.CurrentDate}}"
```

This would result in adding a field like:

`"UpdatedAt": "2025-07-23T19:08:41Z"`
   