### PR TITLE
Feature: create parse fn for transforming stringified objects into actual objects

### DIFF
--- a/app/contexts/command_context.go
+++ b/app/contexts/command_context.go
@@ -1,6 +1,7 @@
 package contexts
 
 import (
+	"encoding/json"
 	"fmt"
 	"strings"
 	"time"
@@ -237,6 +238,27 @@ func ParseValues(jsonMap map[string]interface{}, parse *maps.ParseSettings) map[
 
 			var arrayValue = [1]interface{}{value}
 			jsonValueCurrent = json_map.CreateProperty(jsonMapResult, destinyPropertyName, arrayValue)
+		}
+	}
+
+	if len(parse.ToMap) > 0 {
+		for _, ToMap := range parse.ToMap {
+			ToMapSplitted := strings.Split(ToMap, ":")
+
+			originPropertyName := ToMapSplitted[0]
+			var destinyPropertyName string
+			if len(ToMapSplitted) == 1 {
+				destinyPropertyName = originPropertyName
+			} else {
+				destinyPropertyName = ToMapSplitted[1]
+			}
+
+			value, jsonMapResult := json_map.GetValue(jsonValueCurrent, originPropertyName, true)
+
+			var result map[string]interface{}
+			json.Unmarshal([]byte(fmt.Sprint(value)), &result)
+
+			jsonValueCurrent = json_map.CreateProperty(jsonMapResult, destinyPropertyName, result)
 		}
 	}
 

--- a/app/manifest/contract_settings/maps/parse_settings.go
+++ b/app/manifest/contract_settings/maps/parse_settings.go
@@ -7,14 +7,16 @@ import (
 type ParseSettings struct {
 	WhenEquals []string `yaml:"whenEquals"`
 	ToArray    []string `yaml:"toArray"`
+	ToMap      []string `yaml:"toMap"`
 }
 
 func (setting ParseSettings) Valid() validation.ValidateResult {
 	var result validation.ValidateResult
 
 	if len(setting.WhenEquals) == 0 &&
-		len(setting.ToArray) == 0 {
-		result.AddError("contract.maps.parse should configure whenEquals or toArray")
+		len(setting.ToArray) == 0 &&
+		len(setting.ToMap) == 0 {
+		result.AddError("contract.maps.parse should configure whenEquals, toArray or ToMap")
 	}
 
 	return result

--- a/app/startup/startup_api_endpoints.go
+++ b/app/startup/startup_api_endpoints.go
@@ -26,7 +26,7 @@ func LoadApiEndpoint(ctx context.Context) http.Handler {
 	endpoints := app.Api.Endpoints
 	muxRoute := mux.NewRouter()
 	initialPage := new(InitialPage)
-	initialPage.Append("<h2>Service: " + app.Service.Name + "version: " + app.Service.Version + "</h2>")
+	initialPage.Append("<h2>Service: " + app.Service.Name + " version: " + app.Service.Version + "</h2>")
 	initialPage.Append("<h2>Endpoints</h2>")
 
 	for _, endpoint := range endpoints {


### PR DESCRIPTION
Create "toMap" parse function in order to transform stringified objects into actual objects. So for instance, it changes from:

```"{\"foo\":\"bar\"}" ```

to

```{foo: "bar"}```