### PR TITLE
Fix: auth-validator and HMAC auth

### DIFF
--- a/app/auth/hmac_validation.go
+++ b/app/auth/hmac_validation.go
@@ -1,26 +1,14 @@
 package auth
 
 import (
-	"bytes"
 	"fmt"
-	"io"
-	"net/http"
 	"wrench/app/contexts"
 	"wrench/app/cross_funcs"
 	"wrench/app/manifest/api_settings"
 )
 
-func HMACValidate(r *http.Request, authorizationSettings *api_settings.AuthorizationSettings) bool {
+func HMACValidate(wrenchContext *contexts.WrenchContext, bodyContext *contexts.BodyContext, authorizationSettings *api_settings.AuthorizationSettings) bool {
 	var data = ""
-	bodyContext := new(contexts.BodyContext)
-	wrenchContext := new(contexts.WrenchContext)
-	wrenchContext.Request = r
-
-	body, err := readAndReplaceBody(r)
-	if err != nil {
-		return false
-	}
-	bodyContext.SetBody(body)
 
 	for _, item := range authorizationSettings.ConcatenateFields {
 		data += fmt.Sprint(contexts.GetCalculatedValue(item, wrenchContext, bodyContext, nil))
@@ -32,20 +20,4 @@ func HMACValidate(r *http.Request, authorizationSettings *api_settings.Authoriza
 	actualHash := cross_funcs.GetHash(authorizationSettings.Key, hashFn, []byte(data))
 
 	return expectedHash == actualHash
-}
-
-func readAndReplaceBody(r *http.Request) ([]byte, error) {
-	if r.Body == nil {
-		return nil, nil
-	}
-
-	bodyBytes, err := io.ReadAll(r.Body)
-	if err != nil {
-		return nil, err
-	}
-
-	r.Body.Close()
-	r.Body = io.NopCloser(bytes.NewBuffer(bodyBytes))
-
-	return bodyBytes, nil
 }

--- a/app/handlers/auth_validator_handler.go
+++ b/app/handlers/auth_validator_handler.go
@@ -42,7 +42,7 @@ func (handler *AuthValidatorHandler) Do(ctx context.Context, wrenchContext *cont
 		}
 
 		if authorizationSettings.Type == api_settings.HMACAuthorizationType {
-			isHMACValid := auth.HMACValidate(wrenchContext.Request, authorizationSettings)
+			isHMACValid := auth.HMACValidate(wrenchContext, bodyContext, authorizationSettings)
 			if !isHMACValid {
 				handler.setHasError("Unauthorized", http.StatusUnauthorized, wrenchContext, bodyContext)
 			}
@@ -59,6 +59,8 @@ func (handler *AuthValidatorHandler) SetNext(next Handler) {
 }
 
 func (handler *AuthValidatorHandler) setHasError(msg string, httpStatusCode int, wrenchContext *contexts.WrenchContext, bodyContext *contexts.BodyContext) {
+	wrenchContext.SetHasError2()
+	bodyContext.ContentType = "text/plain"
 	bodyContext.HttpStatusCode = httpStatusCode
 	bodyContext.SetBody([]byte(msg))
 }


### PR DESCRIPTION
auth_validator_handler -> this file had a setHasError function, however, this function was not setting wrenchContext.hasError = true. This is causing the other chain links to execute.

hmac_validation -> this file used to consume the stream from the request body, however, now since its moved to later on in the chain, it was failing to read from body (treated it as empty)